### PR TITLE
update integration platform name

### DIFF
--- a/testcase.yaml
+++ b/testcase.yaml
@@ -2,5 +2,5 @@ tests:
   libcsp.subsec:
     integration_platforms:
       - qemu_cortex_m3
-      - mps2_an385
+      - mps2/an385
     tags: libcsp


### PR DESCRIPTION
The Zephyr Project has introduced Hardware Model Version 2. 
As a result, the platform name 'mps2_an385' in Zephyr has been changed.
Therefore, it is necessary to update the platform name in the test case as well.

I check running :
`west twister -v --integration -T libcsp-zephyr`
I also make sure everything compile.
`west build -b mps2/an385 libcsp-zephyr/`
and run well
`west build -t run`