### PR TITLE
github: workflow: test: Run on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build-test:
-    runs-on:
-      - ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Setup Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Python version
         run: |
           python3 --version

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -7,6 +7,12 @@
 #include <zephyr/ztest.h>
 #include <csp/csp.h>
 
+/* csp_buffer_get_always() is now an internal function
+ * and not exposed in the public API, so we need to
+ * declare it here for testing purposes.
+ */
+csp_packet_t * csp_buffer_get_always(void);
+
 static void *setup(void)
 {
 	csp_init();


### PR DESCRIPTION
To be merged after #5.
This PR adds testing on Windows. It already contains the fix from #5.

The Python version needed to be pinned because Windows runners are stuck on Python 3.9.
Zephyr requires at least 3.10.